### PR TITLE
Radar vehicle search script fixes

### DIFF
--- a/@Kyklop's_EW/addons/kyk_ew/scripts/server/fn_refreshRadar.sqf
+++ b/@Kyklop's_EW/addons/kyk_ew/scripts/server/fn_refreshRadar.sqf
@@ -16,20 +16,23 @@ if(isServer) then
 	kyk_ew_radarVehiclesArray = [];
 
 	{
-		private _sensors = listVehicleSensors _x;
-		private _vehicle = _x;
-		
+		if(!(_x getVariable ["kyk_ew_hasRadar", false])) then
 		{
-			if(_x select 0 == "ActiveRadarSensorComponent") then
+			private _sensors = listVehicleSensors _x;
+			private _vehicle = _x;
+			
 			{
-				_vehicle setVariable ["kyk_ew_hasRadar", true];
-				break;
+				if(_x select 0 == "ActiveRadarSensorComponent") then
+				{
+					_vehicle setVariable ["kyk_ew_hasRadar", true];
+					break;
+				};
+			} forEach _sensors;
+			
+			if(_x getVariable "kyk_ew_hasRadar") then
+			{
+				kyk_ew_radarVehiclesArray append [_x];
 			};
-		} forEach _sensors;
-		
-		if(_x getVariable "kyk_ew_hasRadar") then
-		{
-			kyk_ew_radarVehiclesArray append [_x];
 		};
 	} forEach vehicles;
 };

--- a/@Kyklop's_EW/addons/kyk_ew/scripts/server/fn_refreshRadar.sqf
+++ b/@Kyklop's_EW/addons/kyk_ew/scripts/server/fn_refreshRadar.sqf
@@ -16,10 +16,16 @@ if(isServer) then
 	kyk_ew_radarVehiclesArray = [];
 
 	{
-		if(listVehicleSensors _x select 0 find "ActiveRadarSensorComponent" != -1) then
+		private _sensors = listVehicleSensors _x;
+		private _vehicle = _x;
+		
 		{
-			_x setVariable ["kyk_ew_hasRadar", true];
-		};
+			if(_x select 0 == "ActiveRadarSensorComponent") then
+			{
+				_vehicle setVariable ["kyk_ew_hasRadar", true];
+				break;
+			};
+		} forEach _sensors;
 		
 		if(_x getVariable "kyk_ew_hasRadar") then
 		{


### PR DESCRIPTION
Fixed script not detecting radar-equipped vehicles when the radar sensor is not in the 0 position of the vehicle's sensor-list and optimized the script.